### PR TITLE
Fix path typo

### DIFF
--- a/jenkins_slave/Dockerfile
+++ b/jenkins_slave/Dockerfile
@@ -18,6 +18,6 @@ RUN sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/ssh
 	&& sed -i "s/UsePAM.*/UsePAM no/g" /etc/ssh/sshd_config
 # RUN sed -i "s/#PermitRootLogin.*/PermitRootLogin yes/g" /etc/ssh/sshd_config
 
-RUN echo "AllowGroups jenkins|tee -a /etc/sshd_config"
+RUN echo "AllowGroups jenkins|tee -a /etc/ssh/sshd_config"
 
 CMD ["/bin/sh", "./start.sh"]

--- a/slave_node_alpine/Dockerfile
+++ b/slave_node_alpine/Dockerfile
@@ -20,6 +20,6 @@ RUN sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/ssh
 
 RUN apk --update add git
 
-RUN echo "AllowGroups jenkins|tee -a /etc/sshd_config"
+RUN echo "AllowGroups jenkins|tee -a /etc/ssh/sshd_config"
 
 CMD ["/bin/sh", "./start.sh"]


### PR DESCRIPTION
I have some questions to the recipe:
1. Why wrap the ssh daemon in a script `start.sh` instead of starting is directly?
2. Why call `tee` instead of `echo >>`?
3. Why use `sed` to replace KVs instead of just appending them?

I can only guess that the unusual way of editing the files is to give feedback to the user who runs the script to see that work has actually been done. Iff, for that I prefer to prefix longer `RUN` instructions with a `set -x` which will print all executed instructions, including all after `&&` which could fulfil a similar enough purpose of giving feedback to the run user. 

Regarding `sed`, the patterns don't check if it will replace a commented or uncommented line, therefore leaving the it uncommented if that's the default state. This could result in not achieving the purpose. See the (my current) defaults:

```
#UsePrivilegeSeparation sandbox
#UsePAM no
#PermitRootLogin prohibit-password
```

There `UsePrivilegeSeparation` will actually not be updated and stays `sandbox` (its default); and I believe in some version `UsePAM` default is actually `yes` therefore again only replacing the line without regard of comment symbol would leave it activated.

```
             If UsePAM is enabled, you will not be able to run sshd(8) as a non-root user.
             The default is ``yes''.
```

I believe it's a safer choice to just append the values one wants or include both patterns (commented or uncommented). See http://unix.stackexchange.com/a/2023 and https://github.com/openssh/openssh-portable/blob/master/servconf.c#L2077 

E.g.:

``` dockerfile
RUN set -x \
 && addgroup jenkins \
 && adduser -D jenkins -s /bin/sh -G jenkins \
 && chown -R jenkins:jenkins /home/jenkins \
 && echo "jenkins:jenkins" | chpasswd \
  \
 && ssh-keygen -A \
 && ssh-keygen -A \
 && echo "UsePrivilegeSeparation no" >> /etc/ssh/sshd_config \
 && echo "UsePAM no"                 >> /etc/ssh/sshd_config \
 && echo "PermitRootLogin yes"       >> /etc/ssh/sshd_config \
 && echo "AllowGroups jenkins"       >> /etc/ssh/sshd_config \
  \
 && mkdir -p /home/jenkins/.ssh \
 && echo "ForwardAgent yes" >> /home/jenkins/.ssh/config \
  \
 && mkdir -p /var/jenkins_home \
 && chown jenkins:jenkins /var/jenkins_home

CMD ["/usr/sbin/sshd", "-D"]
```
